### PR TITLE
Fix table row size in preferences dialog and align wrapped text in main entry table

### DIFF
--- a/themes/LightTheme/Interoctiv/wrap-text.css
+++ b/themes/LightTheme/Interoctiv/wrap-text.css
@@ -1,4 +1,10 @@
-.table-view .cell {
-    -fx-cell-size: 4.3em;
-    -fx-wrap-text: true
+/* Enable text wrapping and set alignment in the main table. */
+.notification-pane .table-cell {
+    -fx-wrap-text: true;
+    -fx-alignment: baseline-left
+}
+
+/* Increase cell height to fit two lines. */
+.notification-pane .table-row-cell {
+    -fx-cell-size: 4.3em
 }


### PR DESCRIPTION
Fix excessive height of table rows in the preferences dialog by narrowing CSS selection to the notification pane, and set alignment to `baseline-left` to center text and icons vertically in the main table. Revise CSS selectors to use the style names shown in ScenicView. Fixes #22